### PR TITLE
Experimental: softprops action gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,15 @@
 name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    if: github.event.pull_request.merged
-
     steps:
-      - name: Tag master
-        uses: K-Phoen/semver-release-action@master
-        with:
-          release_branch: master
-          release_strategy: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag 1.x
-        uses: K-Phoen/semver-release-action@master
-        with:
-          release_branch: 1.x
-          release_strategy: tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This is to try https://github.com/softprops/action-gh-release to create new releases with github action, when pushing new tags